### PR TITLE
Fix syntax regarding useplatformtick in bcdedit section of both windows 10 and 11

### DIFF
--- a/AncelsPerformanceBatch.bat
+++ b/AncelsPerformanceBatch.bat
@@ -178,7 +178,7 @@ cls
 :: BCD Tweaks
 echo Applying BCD Tweaks
 bcdedit /set useplatformclock No >> APB_Log.txt
-bcdedit /seplatformtick No >> APB_Log.txt
+bcdedit /set useplatformtick No >> APB_Log.txt
 bcdedit /set disabledynamictick Yes >> APB_Log.txt
 timeout /t 1 /nobreak > NUL
 

--- a/AncelsPerformanceBatch.bat
+++ b/AncelsPerformanceBatch.bat
@@ -136,7 +136,7 @@ cls
 :: BCD Tweaks
 echo Applying BCD Tweaks
 bcdedit /set useplatformclock No >> APB_Log.txt
-bcdedit /set platformtick No >> APB_Log.txt
+bcdedit /set useplatformtick No >> APB_Log.txt
 bcdedit /set disabledynamictick Yes >> APB_Log.txt
 bcdedit /set tscsyncpolicy Enhanced >> APB_Log.txt
 bcdedit /set firstmegabytepolicy UseAll >> APB_Log.txt


### PR DESCRIPTION
At first I saw the "bcdedit /set platformtick No" mistake and thought this would be a no-brainer PR.

But then I saw that the windows 11 section also had a useplatformtick typo, so now I'm wondering if this was intentional? lol

Anyways this should restore expected behaviour if it really was a mistake after all.

![image](https://github.com/user-attachments/assets/6a719bd3-7770-45a5-b9b1-343709cddf64)
